### PR TITLE
respond to new NetworkManager "connectivity-change" event

### DIFF
--- a/50-eos-phone-home
+++ b/50-eos-phone-home
@@ -1,7 +1,9 @@
 #!/bin/sh -e
 
-if [ "${IFACE}" = "lo" ] || \
-   [ "${MODE}" != "start" ] || \
+ACTION=${2}
+
+if [ "${ACTION}" != "connectivity-change" ] || \
+   [ "x${CONNECTIVITY_STATE}" != "xFULL" ] || \
    [ -f /var/lib/eos-phone-home/activated ]; then
     exit 0
 fi

--- a/debian/eos-phone-home.install
+++ b/debian/eos-phone-home.install
@@ -1,5 +1,5 @@
 activate                /usr/lib/eos-phone-home
 eos-phone-home.conf     /usr/lib/tmpfiles.d
-eos-phone-home-if-up    /etc/network/if-up.d
+50-eos-phone-home       /etc/NetworkManager/dispatcher.d
 eos-phone-home.service  /usr/lib/systemd/system
 eos-phone-home.timer    /usr/lib/systemd/system


### PR DESCRIPTION
Similar to https://phabricator.endlessm.com/T12336, move our if-up.d script to
NetworkManager/dispatcher.d so that we can respond to the connectivity-change
action which triggers correctly eg when the user has completed a captive
portal. Otherwise we can "miss" the internet being available because we
activate our script before the user has authenticated.

For https://phabricator.endlessm.com/T12342.