### PR TITLE
add activated file condition to systemd unit

### DIFF
--- a/eos-phone-home.service
+++ b/eos-phone-home.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Send system activation to Endless
 Wants=network.target
+ConditionPathExists!=/var/lib/eos-phone-home/activated
 
 [Service]
 Type=simple


### PR DESCRIPTION
On first boot the .timer job is activated and will inevitably run until the system reboots and the condition stops the timer from running. This means the python activate script is run a few times needlessly and then quits. In the case that the timer is going off but the script has run (eg after the network connectivity changing) then adding the condition to the .service as well as the .timer this makes systemd check that /var/lib/eos-phone-home/activated doesn't exist each time before starting the activate script, saving the overhead of the python intepreter.