### PR TITLE
T13240: fix broken systemd-run invocation

### DIFF
--- a/50-eos-phone-home
+++ b/50-eos-phone-home
@@ -8,6 +8,8 @@ if [ "${ACTION}" != "connectivity-change" ] || \
 fi
 
 # start after 1-2 minutes (AccuracySec defaults to 1min) to allow ntp to sync
-/bin/systemd-run --no-block --on-active=2m --unit=eos-phone-home.service
+# we can't use --unit=eos-phone-home.service here because eos-phone-home.timer already exists
+# starting via systemd also ensures only one instance of the script is running
+/bin/systemd-run --no-block --on-active=2m -- /bin/systemctl --no-block start eos-phone-home.service
 
 exit 0


### PR DESCRIPTION
The systemd-run invocation in the NM dispatcher hook failed because it was trying to create a transient unit named eos-phone-home.timer which is already defined. Change it to create a transient unit which actually in turn calls systemctl to start eos-phone-home.service. This seems a little silly but also has the benefit that systemd will serialise invocations so the script will only be run once at a time.

https://phabricator.endlessm.com/T13240