### PR TITLE
Don't create 'count' file until first ping is sent

### DIFF
--- a/eos-phone-home
+++ b/eos-phone-home
@@ -80,6 +80,9 @@ class PhoneHome(object):
         self._force = force
         self._variables = {}
 
+        self._activated_path = os.path.join(self.STATE_DIRECTORY, 'activated')
+        self._count_path = os.path.join(self.STATE_DIRECTORY, 'count')
+
     # XXX: This is not a regular file - it returns multiple vendor/product
     #      lines that are NUL delimited
     def _get_dt_info(self):
@@ -274,8 +277,7 @@ class PhoneHome(object):
         count = 0
 
         try:
-            with open(os.path.join(self.STATE_DIRECTORY, 'count'), 'r') \
-              as count_file:
+            with open(self._count_path, 'r') as count_file:
                 count_data = count_file.read()
 
             if count_data:
@@ -289,8 +291,7 @@ class PhoneHome(object):
 
     def _set_count(self, count):
         try:
-            with open(os.path.join(self.STATE_DIRECTORY, 'count'), 'w') \
-              as count_file:
+            with open(self._count_path, 'w') as count_file:
                 count_file.write("%d" % count)
 
             self._variables['count'] = count
@@ -356,14 +357,13 @@ class PhoneHome(object):
         return success
 
     def _need_to_activate(self):
-        return not os.path.exists(os.path.join(self.STATE_DIRECTORY,
-                                               'activated'))
+        return not os.path.exists(self._activated_path)
 
     def _do_activate(self):
         if self._send_to_server(self.ACTIVATION_ENDPOINT,
                                 self.ACTIVATION_VARIABLES):
             # We're done, mark us activated
-            with open(os.path.join(self.STATE_DIRECTORY, 'activated'), 'w'):
+            with open(self._activated_path, 'w'):
                 pass
 
             print("Activated!")
@@ -379,13 +379,12 @@ class PhoneHome(object):
             print("Not sending ping from live system.")
             return False
 
-        if not os.path.exists(os.path.join(self.STATE_DIRECTORY, 'count')):
+        if not os.path.exists(self._count_path):
             print("Creating new count file!")
             self._set_count(0)
             return True
 
-        count_time = os.path.getmtime(os.path.join(self.STATE_DIRECTORY,
-                                                   'count'))
+        count_time = os.path.getmtime(self._count_path)
         count_age = time.time() - count_time
         print("Count age:", count_age)
 

--- a/eos-phone-home
+++ b/eos-phone-home
@@ -282,11 +282,13 @@ class PhoneHome(object):
 
             if count_data:
                 count = int(count_data.strip())
-
-            print(" - Count:", count)
+        except FileNotFoundError:
+            pass
         except Exception as e:
             print("Unable to get count!", e, file=sys.stderr)
+            return 0
 
+        print(" - Count:", count)
         return count
 
     def _set_count(self, count):
@@ -379,12 +381,12 @@ class PhoneHome(object):
             print("Not sending ping from live system.")
             return False
 
-        if not os.path.exists(self._count_path):
-            print("Creating new count file!")
-            self._set_count(0)
+        try:
+            count_time = os.path.getmtime(self._count_path)
+        except FileNotFoundError:
+            print("%s doesn't exist yet" % self._count_path)
             return True
 
-        count_time = os.path.getmtime(self._count_path)
         count_age = time.time() - count_time
         print("Count age:", count_age)
 


### PR DESCRIPTION
We'd expect to see approximately the same number of activations as ping 0s submitted to the server, but in fact we see around 10% fewer ping 0s than activations.

`/var/lib/eos-phone-home/count` is meant to contain the number of previous successful pings. At most every 24 hours, we submit a ping containing the contents of this file, then increment the file. Logically, if the file does not exist (as is the case on new installations) the count of previous pings is 0.

Previously, running this script without an active network connection causes `/var/lib/eos-phone-home/count` to be written with value '0'. The value is correct -- no pings have been sent yet -- but the timestamp on this file is used to determine when to send the next ping. If the file was written within the past 24 hours, no ping is sent. So, if the network comes up within the next 24 hours, the activation message will be sent, but not ping 0. After 24 hours, ping 0 would be sent, but short-lived installations would not get that far.

Instead, only write `/var/lib/eos-phone-home/count` after a ping has been sent (or in the time-goes-backwards error case to force the next ping to happen in >= 24 hours). (This already worked correctly for pings after the 0th.)

https://phabricator.endlessm.com/T16966