### PR TITLE
eos-phone-home: Stop sending serial & mac_hash in activations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,4 @@ personally identifiable or trackable information.
 
 As well as the daily "ping" message with an incrementing counter, we are
 implementing a one-off "activate" request so we can tell how many systems have
-been turned on. This request does include the machine serial number, but this
-is only ever sent once per system, so cannot be used for any ongoing tracking.
+been turned on.

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,5 @@ Description: send system activation/daily ping messages to Endless
  Note that this does not send any identifiable user data: it only transmits the
  originally installed operating system version, the current version, the
  machine vendor & product name, and whether the OS metrics system is enabled.
- When the first activation message is sent, it contains the machine serial
- number, but this is not sent again so cannot be used for tracking purposes.
  The daily ping simply contains a cumulative count of how many pings have
  been sent.

--- a/eos-phone-home
+++ b/eos-phone-home
@@ -10,11 +10,7 @@
 # beyond what is needed for IT administration support.
 #
 # The first type of message is an "activation", which is sent only once per
-# system. In addition to the above data, it contains the machine serial number
-# number and a hash of the MAC address of the first non-removable ethernet
-# or wireless network adapter, as some vendors do not set the serial number
-# correctly/uniquely. As the serial and MAC hash is only sent once, it cannot
-# be used for tracking purposes over time.
+# system.
 #
 # The second type of message is a "ping", which is sent at most once per 24
 # hours. In addition to the above data, it contains a counter of how many
@@ -36,11 +32,8 @@
 #  release (from /etc/os-release)
 #  vendor (from DMI / device tree)
 #  product (from DMI / device tree)
-#  serial (from DMI / Endless mfgdata)
 #  live (true if this is a live USB, false if not)
 #  dualboot (true if this is a dual boot installation, false if not)
-#  mac_hash (ADLER32 hash of first non-removable ethernet or wireless
-#            interface MAC address)
 #
 # https://home.endlessm.com/v1/ping
 #
@@ -58,34 +51,31 @@ import argparse
 import collections
 import configparser
 import logging
-import glob
 import os
 import re
 import subprocess
 import time
-import zlib
 
 import requests
 
 log = logging.getLogger(__name__)
 
 Metrics = collections.namedtuple('Metrics', ['enabled', 'environment'])
-ProductInfo = collections.namedtuple('ProductInfo',
-                                     ['vendor', 'product', 'serial'])
+ProductInfo = collections.namedtuple('ProductInfo', ['vendor', 'product'])
 
 
 class PhoneHome(object):
     DEFAULT_API_HOST = 'https://home.endlessm.com'
 
     ACTIVATION_VARIABLES = ('dualboot', 'live', 'image', 'release', 'vendor',
-                            'product', 'serial', 'mac_hash')
+                            'product')
 
     PING_VARIABLES = ('dualboot', 'image', 'release', 'vendor', 'product',
                       'count', 'metrics_enabled', 'metrics_environment')
 
     # variables which should be replaced with "unknown" rather
     # than omitted if the get function returns None
-    MANDATORY_STRINGS = ('image', 'vendor', 'product', 'release', 'serial',
+    MANDATORY_STRINGS = ('image', 'vendor', 'product', 'release',
                          'metrics_environment')
 
     def __init__(self, is_debug, force, root='/', api_host=DEFAULT_API_HOST):
@@ -137,7 +127,6 @@ class PhoneHome(object):
             if os.path.isdir(dmi_dir):
                 vendor = self._read_text(os.path.join(dmi_dir, 'sys_vendor'))
                 product = self._read_text(os.path.join(dmi_dir, 'product_name'))
-                serial = self._read_text(os.path.join(dmi_dir, 'product_serial'))
             else:
                 dt_fields = self._lookup_or_get_variable('dt_info')
                 if dt_fields:
@@ -147,25 +136,18 @@ class PhoneHome(object):
                     vendor = None
                     product = None
 
-                ssn_path = self._resolve_path(
-                    'sys/class/endless_mfgdata/entries/SSN')
-                serial = self._read_text(ssn_path)
-
-            product_info = ProductInfo(vendor, product, serial)
+            product_info = ProductInfo(vendor, product)
             log.info(" - Found product info: %s", product_info)
             return product_info
         except Exception:
             log.exception("Unable to get product info!")
-            return ProductInfo(None, None, None)
+            return ProductInfo(None, None)
 
     def _get_vendor(self):
         return self._lookup_or_get_variable('product_info').vendor
 
     def _get_product(self):
         return self._lookup_or_get_variable('product_info').product
-
-    def _get_serial(self):
-        return self._lookup_or_get_variable('product_info').serial
 
     def _get_image(self):
         image = None
@@ -273,55 +255,6 @@ class PhoneHome(object):
             return True
 
         return False
-
-    def _get_mac_hash(self):
-        try:
-            eth_ifaces = []
-            wlan_ifaces = []
-
-            for iface in glob.glob(self._resolve_path('sys/class/net/*')):
-                # skip virtual interfaces
-                device = os.path.join(iface, 'device')
-                if not os.path.exists(device):
-                    continue
-
-                # skip USB devices
-                subsystem = os.readlink(os.path.join(device, 'subsystem'))
-                if os.path.basename(subsystem) == 'usb':
-                    continue
-
-                # build separate list of wireless interfaces
-                if os.path.exists(os.path.join(iface, 'wireless')):
-                    wlan_ifaces.append(iface)
-                else:
-                    eth_ifaces.append(iface)
-
-            # prefer the fixed interfaces if there are any, wireless if not
-            if eth_ifaces:
-                ifaces = eth_ifaces
-            elif wlan_ifaces:
-                ifaces = wlan_ifaces
-            else:
-                return None
-
-            devs = {}
-            for iface in ifaces:
-                with open(os.path.join(iface, 'address')) as mac_file:
-                    mac = mac_file.read().strip().lower()
-                dev = os.path.basename(iface)
-                devs[mac] = dev
-
-            mac = sorted(devs.keys())[0]
-            mac_hash = zlib.adler32(mac.encode('utf-8'))
-
-            log.info(" - Selected dev %s address %s", devs[mac], mac)
-            log.info(" - Found MAC hash: %u", mac_hash)
-
-            return mac_hash
-        except Exception:
-            log.exception("Unable to get mac_hash!")
-
-            return None
 
     def _get_count(self):
         count = 0

--- a/test_eos-phone-home.py
+++ b/test_eos-phone-home.py
@@ -24,36 +24,14 @@ def test_get_product_info_arm(tmpdir, app):
                                                b'vendor2,model2\0',
                                                ensure=True)
 
-    endless_serial_number_file = tmpdir.join('sys', 'class',
-                                             'endless_mfgdata', 'entries',
-                                             'SSN')
-    endless_serial_number_file.write('  serial  ', ensure=True)
-
     product_info = app._get_product_info()
-    expected = eos_phone_home.ProductInfo('vendor1', 'model1', 'serial')
-    assert product_info == expected
-
-
-def test_get_product_info_arm_missing_serial(tmpdir, app):
-    device_tree_product_info_file = tmpdir.join('proc', 'device-tree',
-                                                'compatible')
-    device_tree_product_info_file.write_binary(b'vendor1,model1\0'
-                                               b'vendor2,model2\0',
-                                               ensure=True)
-
-    product_info = app._get_product_info()
-    expected = eos_phone_home.ProductInfo('vendor1', 'model1', None)
+    expected = eos_phone_home.ProductInfo('vendor1', 'model1')
     assert product_info == expected
 
 
 def test_get_product_info_arm_missing_dt(tmpdir, app):
-    endless_serial_number_file = tmpdir.join('sys', 'class',
-                                             'endless_mfgdata', 'entries',
-                                             'SSN')
-    endless_serial_number_file.write('  serial  ', ensure=True)
-
     product_info = app._get_product_info()
-    expected = eos_phone_home.ProductInfo(None, None, 'serial')
+    expected = eos_phone_home.ProductInfo(None, None)
     assert product_info == expected
 
 
@@ -61,20 +39,18 @@ def test_get_product_info_x86(tmpdir, app):
     dmi_dir = tmpdir.join('sys', 'class', 'dmi', 'id')
     dmi_dir.join('sys_vendor').write('  vendor', ensure=True)
     dmi_dir.join('product_name').write(' product')
-    dmi_dir.join('product_serial').write('serial  ')
 
     product_info = app._get_product_info()
-    expected = eos_phone_home.ProductInfo('vendor', 'product', 'serial')
+    expected = eos_phone_home.ProductInfo('vendor', 'product')
     assert product_info == expected
 
 
 def test_get_product_info_x86_missing_vendor(tmpdir, app):
     dmi_dir = tmpdir.join('sys', 'class', 'dmi', 'id')
     dmi_dir.join('product_name').write(' product', ensure=True)
-    dmi_dir.join('product_serial').write('serial  ')
 
     product_info = app._get_product_info()
-    expected = eos_phone_home.ProductInfo(None, 'product', 'serial')
+    expected = eos_phone_home.ProductInfo(None, 'product')
     assert product_info == expected
 
 
@@ -133,8 +109,6 @@ def test_build_activation_request_when_fields_cannot_be_determined(tmpdir,
         'release': 'unknown',
         'vendor': 'unknown',
         'product': 'unknown',
-        'serial': 'unknown',
-        # mac_hash, however, is omitted if it can't be determined.
     }
 
 


### PR DESCRIPTION
According to the new design of Metrics for EOS 4, we no longer need to
collect serial & mac_hash in activations and should stop submitting
them. This commit removes all of corresponding serial & mac_hash code
and information.

https://phabricator.endlessm.com/T31993