### PR TITLE
Support config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Endless OS "Phone Home"
------------------------
+# Endless OS "Phone Home"
 
 This is inspired by https://launchpad.net/canonical-poke imported from bzr to git
 on Sat 9th July 2016. The "census" (simple sqlite stats processing) and
@@ -8,9 +7,32 @@ history and separate bzr branch for reference, but later removed.
 
 We are using the anonymous counting approach as set out in
 http://theravingrick.blogspot.co.uk/2010/08/can-we-count-users-without-uniquely.html
-so that Endless can dermine the number of active systems without sending any
+so that Endless can determine the number of active systems without sending any
 personally identifiable or trackable information.
 
 As well as the daily "ping" message with an incrementing counter, we are
 implementing a one-off "activate" request so we can tell how many systems have
 been turned on.
+
+## Configuration
+
+`eos-phone-home` can be configured using the INI formatted file
+`/etc/eos-phone-home.conf`. Options passed to `eos-phone-home` on the command
+line take precedence over the configuration file.
+
+The following settings are supported in the `global` section:
+
+* `host` - The API server URL. (Default: `https://home.endlessm.com`)
+* `debug` - Enable verbose output and disable any actual phoning home.
+  (Default: `false`)
+* `force` - Always collect data and enable verbose output. (Default: `false`)
+* `exit_on_server_error` - Exit with a non-0 status if activation and/or ping
+  can't be sent to the server. (Default: `false`)
+
+For example:
+
+```
+[global]
+host = https://home.example.com
+exit_on_server_error = true
+```

--- a/eos-phone-home
+++ b/eos-phone-home
@@ -152,7 +152,7 @@ class PhoneHome(object):
     def _get_image(self):
         image = None
 
-        for path in ['/sysroot', '/']:
+        for path in ['sysroot', '']:
             path = self._resolve_path(path)
             try:
                 image = subprocess.check_output(['attr', '-q', '-g',

--- a/eos-phone-home
+++ b/eos-phone-home
@@ -50,6 +50,7 @@
 import argparse
 import collections
 import configparser
+import dataclasses
 import logging
 import os
 import re
@@ -62,6 +63,8 @@ log = logging.getLogger(__name__)
 
 Metrics = collections.namedtuple('Metrics', ['enabled', 'environment'])
 ProductInfo = collections.namedtuple('ProductInfo', ['vendor', 'product'])
+
+DEFAULT_CONFIG_PATH = '/etc/eos-phone-home.conf'
 
 
 class PhoneHome(object):
@@ -442,21 +445,106 @@ class PhoneHome(object):
             exit(1)
 
 
+@dataclasses.dataclass
+class Config:
+    """eos-phone-home configuration"""
+    host: str = PhoneHome.DEFAULT_API_HOST
+    debug: bool = False
+    force: bool = False
+    exit_on_server_error: bool = False
+
+    @classmethod
+    def from_path(cls, path=DEFAULT_CONFIG_PATH, overrides=None):
+        """Read the configuration file at path and return a Config instance
+
+        The configuration file is INI formatted with a single global section.
+        The options in the global section correspond to the Config fields.
+
+        Additional settings can be set in the overrides dictionary. These
+        settings take precedence over the configuration file settings.
+        """
+        if overrides is None:
+            overrides = {}
+
+        cp = configparser.ConfigParser()
+
+        try:
+            with open(path, 'r') as cf:
+                cp.read_file(cf)
+        except FileNotFoundError:
+            if path != DEFAULT_CONFIG_PATH:
+                log.warning(f'Configuration file "{path}" does not exist')
+
+        # Build the settings in a dict.
+        settings = {}
+        for field in dataclasses.fields(cls):
+            # Get the override value.
+            value = overrides.get(field.name, None)
+
+            # Fallback to the value from the config file.
+            if value is None:
+                if field.type == bool:
+                    getval = cp.getboolean
+                else:
+                    getval = cp.get
+                value = getval('global', field.name, fallback=None)
+
+            if value is not None:
+                settings[field.name] = value
+
+        return cls(**settings)
+
+
 def main():
-    p = argparse.ArgumentParser()
-    p.add_argument('--debug', action='store_true',
-                   help='verbose output; disables any actual phoning home')
-    p.add_argument('-t', '--host', default=PhoneHome.DEFAULT_API_HOST,
-                   help='Use specified host as the API server. Default: ' +
-                        PhoneHome.DEFAULT_API_HOST)
-    p.add_argument('--force', action='store_true',
-                   help='always collect data (implies --debug)')
-    p.add_argument('--exit-on-server-error', action='store_true',
-                   help='exit with a non-0 status if activation and/or ping '
-                        "can't be sent to the server")
+    p = argparse.ArgumentParser(
+        description='Send anonymous events for counting Endless users',
+        epilog=(
+            f'eos-phone-home can also be configured {DEFAULT_CONFIG_PATH} or '
+            'the file specified in --config. Any options specified on the '
+            'command line take precedence over the configuration file.'
+        ),
+    )
+    p.add_argument(
+        '-c',
+        '--config',
+        default=DEFAULT_CONFIG_PATH,
+        help='Configuration file to use. Default: %(default)s',
+    )
+    p.add_argument(
+        '--debug',
+        action='store_true',
+        default=None,
+        help='verbose output; disables any actual phoning home',
+    )
+    p.add_argument(
+        '-t',
+        '--host',
+        default=None,
+        help=(
+            'Use specified host as the API server. Default: '
+            f'{PhoneHome.DEFAULT_API_HOST}'
+        ),
+    )
+    p.add_argument(
+        '--force',
+        action='store_true',
+        default=None,
+        help='always collect data (implies --debug)',
+    )
+    p.add_argument(
+        '--exit-on-server-error',
+        action='store_true',
+        default=None,
+        help=(
+            'exit with a non-0 status if activation and/or ping '
+            "can't be sent to the server"
+        ),
+    )
 
     args = p.parse_args()
-    is_debug = args.debug or args.force
+    config = Config.from_path(args.config, vars(args))
+
+    is_debug = config.debug or config.force
     if is_debug:
         log.info("Debugging turned on!")
         level = logging.DEBUG
@@ -464,8 +552,8 @@ def main():
         level = logging.INFO
     logging.basicConfig(level=level)
 
-    app = PhoneHome(is_debug, args.force, api_host=args.host)
-    app.run(args.exit_on_server_error)
+    app = PhoneHome(is_debug, config.force, api_host=config.host)
+    app.run(config.exit_on_server_error)
 
 
 if __name__ == '__main__':

--- a/eos-phone-home
+++ b/eos-phone-home
@@ -88,8 +88,9 @@ class PhoneHome(object):
         self._activated_path = os.path.join(self._state_directory, 'activated')
         self._count_path = os.path.join(self._state_directory, 'count')
 
-        self._activation_endpoint = api_host + '/v1/activate'
-        self._ping_endpoint = api_host + '/v1/ping'
+        self._api_host = api_host
+        self._activation_endpoint = self._api_host + '/v1/activate'
+        self._ping_endpoint = self._api_host + '/v1/ping'
 
     def _resolve_path(self, relpath):
         '''Resolves 'relpath' against the root directory passed to the

--- a/test_eos-phone-home.py
+++ b/test_eos-phone-home.py
@@ -1,11 +1,17 @@
-import imp
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
 import os
+import sys
 
 import pytest
 
 SRCDIR = os.path.dirname(__file__)
 eos_phone_home_path = os.path.join(SRCDIR, 'eos-phone-home')
-eos_phone_home = imp.load_source("m", eos_phone_home_path)
+eos_phone_home_loader = SourceFileLoader('eos_phone_home', eos_phone_home_path)
+eos_phone_home_spec = spec_from_loader('eos_phone_home', eos_phone_home_loader)
+eos_phone_home = module_from_spec(eos_phone_home_spec)
+sys.modules['eos_phone_home'] = eos_phone_home
+eos_phone_home_spec.loader.exec_module(eos_phone_home)
 
 
 @pytest.fixture


### PR DESCRIPTION
Support configuring through `/etc/metrics/eos-phone-home.conf` (bikeshedding allowed). The primary use case is to override the server URL without having to change the command line arguments. While here, add a bit more testing and stop use of a deprecated module.

https://phabricator.endlessm.com/T35420